### PR TITLE
periph-smoketest: Move tests from package to smoketest.

### DIFF
--- a/periph-smoketest/gpiosmoketest/README.md
+++ b/periph-smoketest/gpiosmoketest/README.md
@@ -1,70 +1,73 @@
-# 'gpio' smoke test
+# Testing
 
-Verifies that the library physically work. It requires the user to connect two
-GPIO pins together and provide their pin number at the command line.
+The tests implemented perform *functional* tests of the library. This means that 
+the tests performed interact with a GPIO chipset, and perform actual read/write 
+operations. Using this test set, it's possible to quickly and accurately check 
+if the library is working as expected on a specific hardware/kernel combination.
 
-Example output running on a Raspberry Pi:
+## Requirements
+
+Although the library is not Raspberry Pi specific, the GPIO pin names used for 
+tests are.
+
+As written, the tests must be executed on a Raspberry Pi SBC running Linux. Tested 
+models are:
+
+* Raspberry Pi 3B
+* Raspberry Pi Zero W
+* Raspberry Pi 4
+* Raspberry Pi 5
+
+You must also have the golang SDK installed.
+
+## Setting Up
+
+In order to execute the functional tests, you must jumper the sets of pins shown 
+below together.
+
+For example, the single line tests require GPIO5 and GPIO13 to be connected to 
+each other, so a jumper is required between pins 29 and 33. For the multi-line 
+tests to work, you must connect the following GPIO pins together with jumpers.
+
+| GPIO Output | Output Pin # | GPIO Input | Input Pin # |
+| ----------- | ------------ | ---------- | ----------- |
+| GPIO2       |            3 | GPIO10     |          19 |
+| GPIO3       |            5 | GPIO11     |          23 |
+| GPIO4       |            7 | GPIO12     |          32 |
+| GPIO5       |           29 | GPIO13     |          33 |
+| GPIO6       |           31 | GPIO14     |           8 |
+| GPIO7       |           26 | GPIO15     |          10 |
+| GPIO8       |           24 | GPIO16     |          36 |
+| GPIO9       |           21 | GPIO17     |          11 |
+
+## Cross-Compiling
+If you don't have a working go installation on the target machine, you can cross
+compile from one machine and then copy the test binary to the target machine.
+
+To cross compile for Raspberry Pi, execute the command:
+
+```bash
+$periph.io/x/host/gpioctl> GOOS=linux GOARCH=arm64 go test -c
+$periph.io/x/host/gpioctl> scp gpioioctl.test user@test.machine:~
+$periph.io/x/host/gpioctl> ssh user@test.machine
+$user> ./gpioioctl.test -test.v
+```
+for Pi Zero W, use:
+
+```bash
+$periph.io/x/host/gpioctl> GOOS=linux GOARCH=arm GOARM=6 go test -c
+$periph.io/x/host/gpioctl> scp gpioioctl.test user@test.machine:~
+$periph.io/x/host/gpioctl> ssh user@test.machine
+$user> ./gpioioctl.test -test.v
 
 ```
-$ gpio-test 12 6
-Using drivers:
-  - bcm283x
-  - rpi
-  - sysfs-gpio
-  - sysfs-spi
-  - sysfs-i2c
-Using pins and their current state:
-- GPIO12: In/High
-- GPIO6: In/High
 
-Testing GPIO6 -> GPIO12
-  Testing base functionality
-    GPIO12.In(Float)
-    GPIO6.Out(Low)
-    -> GPIO12: In/Low
-    -> GPIO6: Out/Low
-    GPIO6.Out(High)
-    -> GPIO12: In/High
-    -> GPIO6: Out/High
-  Testing edges
-    GPIO12.Edges()
-    GPIO6.Out(Low)
-    Low <- GPIO12
-    GPIO6.Out(High)
-    High <- GPIO12
-    GPIO6.Out(Low)
-    Low <- GPIO12
-    GPIO12.DisableEdges()
-  Testing pull resistor
-    GPIO6.In(Down)
-    -> GPIO12: In/Low
-    -> GPIO6: In/Low
-    GPIO6.In(Up)
-    -> GPIO12: In/High
-    -> GPIO6: In/High
-Testing GPIO12 -> GPIO6
-  Testing base functionality
-    GPIO6.In(Float)
-    GPIO12.Out(Low)
-    -> GPIO6: In/Low
-    -> GPIO12: Out/Low
-    GPIO12.Out(High)
-    -> GPIO6: In/High
-    -> GPIO12: Out/High
-  Testing edges
-    GPIO6.Edges()
-    GPIO12.Out(Low)
-    Low <- GPIO6
-    GPIO12.Out(High)
-    High <- GPIO6
-    GPIO12.Out(Low)
-    Low <- GPIO6
-    GPIO6.DisableEdges()
-  Testing pull resistor
-    GPIO12.In(Down)
-    -> GPIO6: In/Low
-    -> GPIO12: In/Low
-    GPIO12.In(Up)
-    -> GPIO6: In/High
-    -> GPIO12: In/High
+## Executing the Tests
+
+After connecting the jumper wires as shown above, and you have golang installed 
+and the go/bin directory in the path, change to this directory and execute the 
+command:
+
+```bash
+$> go test -v -cover
 ```

--- a/periph-smoketest/gpiosmoketest/gpio.go
+++ b/periph-smoketest/gpiosmoketest/gpio.go
@@ -12,7 +12,7 @@ import (
 
 	"periph.io/x/conn/v3/driver/driverreg"
 	"periph.io/x/conn/v3/gpio"
-    "periph.io/x/host/v3/gpioioctl"
+	"periph.io/x/host/v3/gpioioctl"
 )
 
 const (
@@ -22,6 +22,25 @@ const (
 
 func init() {
 	_, _ = driverreg.Init()
+}
+
+// Test the consumer field. Since this actually configures a line for output,
+// it actually tests a fair amount of the code to request a line, and configure
+// it.
+func TestConsumer(t *SmokeTestT) {
+	l := gpioioctl.Chips[0].ByName(_OUT_LINE)
+	if l == nil {
+		t.Fatalf("Error retrieving GPIO Line %s", _OUT_LINE)
+	}
+	defer l.Close()
+	// Consumer isn't written until the line is configured.
+	err := l.Out(true)
+	if err != nil {
+		t.Errorf("l.Out() %s", err)
+	}
+	if len(l.Consumer()) == 0 {
+		t.Error("No consumer name found.")
+	}
 }
 
 func TestWriteReadSinglePin(t *SmokeTestT) {

--- a/periph-smoketest/gpiosmoketest/gpio.go
+++ b/periph-smoketest/gpiosmoketest/gpio.go
@@ -1,0 +1,163 @@
+package gpiosmoketest
+
+// Copyright 2024 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+//
+// The In/Out tests depend upon having a jumper wire connecting _OUT_LINE and
+// _IN_LINE
+
+import (
+	"time"
+
+	"periph.io/x/conn/v3/driver/driverreg"
+	"periph.io/x/conn/v3/gpio"
+    "periph.io/x/host/v3/gpioioctl"
+)
+
+const (
+	_OUT_LINE = "GPIO5"
+	_IN_LINE  = "GPIO13"
+)
+
+func init() {
+	_, _ = driverreg.Init()
+}
+
+func TestWriteReadSinglePin(t *SmokeTestT) {
+	var err error
+	chip := gpioioctl.Chips[0]
+	inLine := chip.ByName(_IN_LINE)
+	outLine := chip.ByName(_OUT_LINE)
+	defer inLine.Close()
+	defer outLine.Close()
+	err = outLine.Out(true)
+	if err != nil {
+		t.Errorf("outLine.Out() %s", err)
+	}
+	if val := inLine.Read(); !val {
+		t.Error("Error reading/writing GPIO Pin. Expected true, received false!")
+	}
+	if inLine.Pull() != gpio.PullUp {
+		t.Errorf("Pull() returned %s expected %s", gpioioctl.PullLabels[inLine.Pull()], gpioioctl.PullLabels[gpio.PullUp])
+	}
+	err = outLine.Out(false)
+	if err != nil {
+		t.Errorf("outLine.Out() %s", err)
+	}
+	if val := inLine.Read(); val {
+		t.Error("Error reading/writing GPIO Pin. Expected false, received true!")
+	}
+	/*
+		By Design, lines should auto change directions if Read()/Out() are called
+		and they don't match.
+	*/
+	err = inLine.Out(false)
+	if err != nil {
+		t.Errorf("inLine.Out() %s", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	err = inLine.Out(true)
+	if err != nil {
+		t.Errorf("inLine.Out() %s", err)
+	}
+	if val := outLine.Read(); !val {
+		t.Error("Error read/writing with auto-reverse of line functions.")
+	}
+	err = inLine.Out(false)
+	if err != nil {
+		t.Errorf("TestWriteReadSinglePin() %s", err)
+	}
+	if val := outLine.Read(); val {
+		t.Error("Error read/writing with auto-reverse of line functions.")
+	}
+
+}
+
+func clearEdges(line gpio.PinIn) bool {
+	result := false
+	for line.WaitForEdge(10 * time.Millisecond) {
+		result = true
+	}
+	return result
+}
+
+func TestWaitForEdgeTimeout(t *SmokeTestT) {
+	line := gpioioctl.Chips[0].ByName(_IN_LINE)
+	defer line.Close()
+	err := line.In(gpio.PullUp, gpio.BothEdges)
+	if err != nil {
+		t.Error(err)
+	}
+	clearEdges(line)
+	tStart := time.Now().UnixMilli()
+	line.WaitForEdge(5 * time.Second)
+	tEnd := time.Now().UnixMilli()
+	tDiff := tEnd - tStart
+	if tDiff < 4500 || tDiff > 5500 {
+		t.Errorf("timeout duration failure. Expected duration: 5000, Actual duration: %d", tDiff)
+	}
+}
+
+// Test detection of rising, falling, and both.
+func TestWaitForEdgeSinglePin(t *SmokeTestT) {
+	tests := []struct {
+		startVal gpio.Level
+		edge     gpio.Edge
+		writeVal gpio.Level
+	}{
+		{startVal: false, edge: gpio.RisingEdge, writeVal: true},
+		{startVal: true, edge: gpio.FallingEdge, writeVal: false},
+		{startVal: false, edge: gpio.BothEdges, writeVal: true},
+		{startVal: true, edge: gpio.BothEdges, writeVal: false},
+	}
+	var err error
+	line := gpioioctl.Chips[0].ByName(_IN_LINE)
+	outLine := gpioioctl.Chips[0].ByName(_OUT_LINE)
+	defer line.Close()
+	defer outLine.Close()
+
+	for _, test := range tests {
+		err = outLine.Out(test.startVal)
+		if err != nil {
+			t.Errorf("set initial value. %s", err)
+		}
+		err = line.In(gpio.PullUp, test.edge)
+		if err != nil {
+			t.Errorf("line.In() %s", err)
+		}
+		clearEdges(line)
+		err = outLine.Out(test.writeVal)
+		if err != nil {
+			t.Errorf("outLine.Out() %s", err)
+		}
+		if edgeReceived := line.WaitForEdge(time.Second); !edgeReceived {
+			t.Errorf("Expected Edge %s was not received on transition from %t to %t", gpioioctl.EdgeLabels[test.edge], test.startVal, test.writeVal)
+		}
+	}
+}
+
+func TestHalt(t *SmokeTestT) {
+	line := gpioioctl.Chips[0].ByName(_IN_LINE)
+	defer line.Close()
+	err := line.In(gpio.PullUp, gpio.BothEdges)
+	if err != nil {
+		t.Fatalf("TestHalt() %s", err)
+	}
+	clearEdges(line)
+	// So what we'll do here is setup a goroutine to wait three seconds and then send a halt.
+	go func() {
+		time.Sleep(time.Second * 3)
+		err = line.Halt()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	tStart := time.Now().UnixMilli()
+	line.WaitForEdge(time.Second * 30)
+	tEnd := time.Now().UnixMilli()
+	tDiff := tEnd - tStart
+	if tDiff > 3500 {
+		t.Errorf("error calling halt to interrupt WaitForEdge() Duration %d exceeded expected value.", tDiff)
+	}
+}

--- a/periph-smoketest/gpiosmoketest/gpioioctlsmoketest.go
+++ b/periph-smoketest/gpiosmoketest/gpioioctlsmoketest.go
@@ -1,14 +1,13 @@
-// Copyright 2025 The Periph Authors. All rights reserved.
+// Copyright 2024 The Periph Authors. All rights reserved.
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
-
-// Package gpioioctlsmoketest is leveraged by periph-smoketest to verify that basic
-// GPIO pin functionality works.
+//
+// Functional smoke test for the host/gpioioctl package.
 package gpiosmoketest
 
 import (
-    "errors"
-    "flag"
+	"errors"
+	"flag"
 	"log"
 )
 
@@ -37,7 +36,7 @@ func (st *SmokeTestT) Log(args ...any) {
 	log.Println(args...)
 }
 func (st *SmokeTestT) Logf(format string, args ...any) {
-    log.Printf(format, args...)
+	log.Printf(format, args...)
 }
 func (st *SmokeTestT) ErrorsOrFatals() bool {
 	return st.error || st.fatal
@@ -69,9 +68,8 @@ func (s *SmokeTest) Run(f *flag.FlagSet, args []string) error {
 	TestLineSetHalt(st)
 	TestLineSetWaitForEdge(st)
 	TestLineSetConfigWithOverride(st)
-    if st.ErrorsOrFatals() {
-        return errors.New("Smoketest failure.")
-    }
-    return nil
+	if st.ErrorsOrFatals() {
+		return errors.New("Smoketest failure.")
+	}
+	return nil
 }
-

--- a/periph-smoketest/gpiosmoketest/gpioioctlsmoketest.go
+++ b/periph-smoketest/gpiosmoketest/gpioioctlsmoketest.go
@@ -1,0 +1,77 @@
+// Copyright 2025 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package gpioioctlsmoketest is leveraged by periph-smoketest to verify that basic
+// GPIO pin functionality works.
+package gpiosmoketest
+
+import (
+    "errors"
+    "flag"
+	"log"
+)
+
+type SmokeTestT struct {
+	error bool
+	fatal bool
+}
+
+func (st *SmokeTestT) Error(args ...any) {
+	st.error = true
+	log.Println(args...)
+}
+func (st *SmokeTestT) Errorf(format string, args ...any) {
+	st.error = true
+	log.Printf(format, args...)
+}
+func (st *SmokeTestT) Fatal(args ...any) {
+	st.fatal = true
+	log.Fatal(args...)
+}
+func (st *SmokeTestT) Fatalf(format string, args ...any) {
+	st.fatal = true
+	log.Fatalf(format, args...)
+}
+func (st *SmokeTestT) Log(args ...any) {
+	log.Println(args...)
+}
+func (st *SmokeTestT) Logf(format string, args ...any) {
+    log.Printf(format, args...)
+}
+func (st *SmokeTestT) ErrorsOrFatals() bool {
+	return st.error || st.fatal
+}
+
+type SmokeTest struct {
+}
+
+// Name implements periph-smoketest.SmokeTest.
+func (s *SmokeTest) Name() string {
+	return "gpio"
+}
+
+// Description implements periph-smoketest.SmokeTest.
+func (s *SmokeTest) Description() string {
+	return "Tests basic functionality, edge detection and input pull resistors"
+}
+
+// Run implements periph-smoketest.SmokeTest.
+func (s *SmokeTest) Run(f *flag.FlagSet, args []string) error {
+	st := &SmokeTestT{}
+	TestWriteReadSinglePin(st)
+	TestWaitForEdgeTimeout(st)
+	TestWaitForEdgeSinglePin(st)
+	TestHalt(st)
+	TestLineSetCreation(st)
+	TestLineSetReadWrite(st)
+	TestLineSetWaitForEdgeTimeout(st)
+	TestLineSetHalt(st)
+	TestLineSetWaitForEdge(st)
+	TestLineSetConfigWithOverride(st)
+    if st.ErrorsOrFatals() {
+        return errors.New("Smoketest failure.")
+    }
+    return nil
+}
+

--- a/periph-smoketest/gpiosmoketest/lineset.go
+++ b/periph-smoketest/gpiosmoketest/lineset.go
@@ -3,14 +3,14 @@ package gpiosmoketest
 // Copyright 2024 The Periph Authors. All rights reserved.
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
-//
+
 // This is the set of tests for the LineSet functionality.
 
 import (
 	"time"
 
 	"periph.io/x/conn/v3/gpio"
-    "periph.io/x/host/v3/gpioioctl"
+	"periph.io/x/host/v3/gpioioctl"
 )
 
 var outputLines = []string{"GPIO2", "GPIO3", "GPIO4", "GPIO5", "GPIO6", "GPIO7", "GPIO8", "GPIO9"}

--- a/periph-smoketest/gpiosmoketest/lineset.go
+++ b/periph-smoketest/gpiosmoketest/lineset.go
@@ -1,0 +1,317 @@
+package gpiosmoketest
+
+// Copyright 2024 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+//
+// This is the set of tests for the LineSet functionality.
+
+import (
+	"time"
+
+	"periph.io/x/conn/v3/gpio"
+    "periph.io/x/host/v3/gpioioctl"
+)
+
+var outputLines = []string{"GPIO2", "GPIO3", "GPIO4", "GPIO5", "GPIO6", "GPIO7", "GPIO8", "GPIO9"}
+var inputLines = []string{"GPIO10", "GPIO11", "GPIO12", "GPIO13", "GPIO14", "GPIO15", "GPIO16", "GPIO17"}
+
+func verifyLineSet(t *SmokeTestT,
+	chip *gpioioctl.GPIOChip,
+	lsTest *gpioioctl.LineSet,
+	direction gpioioctl.LineDir,
+	lines []string) {
+	lsTestLines := lsTest.Lines()
+	if lsTest.LineCount() != len(lines) || len(lsTestLines) != lsTest.LineCount() {
+		t.Errorf("lineset does not match length of lines %#v", lines)
+	}
+	s := lsTest.String()
+	if len(s) == 0 {
+		t.Error("error - empty string")
+	}
+
+	// Verify each individual line is as expected.
+	for ix, lineName := range lines {
+		lsl := lsTestLines[ix]
+		line := chip.ByName(lineName)
+		if lsl.Offset() != uint32(ix) {
+			t.Errorf("Unexpected offset in LineSetLine. Expected: %d Found %d", ix, lsl.Offset())
+		}
+		if lsl.Name() != line.Name() {
+			t.Errorf("Expected LineSetLine.Name()=%s, found %s", lineName, lsl.Name())
+		}
+		if lsl.Number() != line.Number() {
+			t.Errorf("Expected LineSetLine.Number()=%d, found %d", line.Number(), lsl.Number())
+		}
+		if lsl.Offset() != uint32(ix) {
+			t.Errorf("Line # %d, expected offset %d, got %d", lsl.Number(), ix, lsl.Offset())
+		}
+		if lsl.Direction() != direction {
+			t.Errorf("Expected LineSetLine.direction=%s, found %s", gpioioctl.DirectionLabels[direction], gpioioctl.DirectionLabels[lsl.Direction()])
+		}
+		s := lsl.String()
+		if len(s) == 0 {
+			t.Error("LineSetLine.String() returned empty string.")
+		}
+		e := lsl.Halt()
+		if e == nil {
+			t.Error("LineSetLine.Halt() should return an error!")
+		}
+	}
+}
+
+func createLineSets(t *SmokeTestT, chip *gpioioctl.GPIOChip, edge gpio.Edge) (lsOutput *gpioioctl.LineSet, lsInput *gpioioctl.LineSet) {
+	// Create the Output Lineset
+	lsOutput, err := chip.LineSet(gpioioctl.LineOutput, gpio.NoEdge, gpio.PullNoChange, outputLines...)
+	if err != nil {
+		t.Fatalf("Error creating output LineSet %s", err.Error())
+	}
+
+	verifyLineSet(t, chip, lsOutput, gpioioctl.LineOutput, outputLines)
+
+	// Create the Input LineSet
+	lsInput, err = chip.LineSet(gpioioctl.LineInput, edge, gpio.PullUp, inputLines...)
+	if err != nil {
+		t.Fatalf("Error creating input LineSet %s", err.Error())
+	}
+
+	verifyLineSet(t, chip, lsInput, gpioioctl.LineInput, inputLines)
+	return
+}
+
+// Test Creating the line set and verify the pin setups.
+func TestLineSetCreation(t *SmokeTestT) {
+	chip := gpioioctl.Chips[0]
+	lsOutput, lsInput := createLineSets(t, chip, gpio.NoEdge)
+	if lsOutput != nil {
+		errClose := lsOutput.Close()
+		if errClose != nil {
+			t.Errorf("Closing Output LineSet %v", errClose)
+		}
+	}
+	if lsInput != nil {
+		errClose := lsInput.Close()
+		if errClose != nil {
+			t.Errorf("Closing Output LineSet %v", errClose)
+		}
+
+	}
+}
+
+// Test writing to the output set and reading from the input set.
+func TestLineSetReadWrite(t *SmokeTestT) {
+	chip := gpioioctl.Chips[0]
+	lsOutput, lsInput := createLineSets(t, chip, gpio.NoEdge)
+	if lsOutput == nil || lsInput == nil {
+		return
+	}
+	defer lsOutput.Close()
+	defer lsInput.Close()
+	limit := (1 << len(outputLines)) - 1
+	mask := uint64(limit)
+	for i := range limit {
+		// Test Read of all pins in the set at once.
+		//
+		// Generally, if this is failing double-check your
+		// jumper wires between pins.
+		//
+		err := lsOutput.Out(uint64(i), mask)
+		if err != nil {
+			t.Errorf("Error writing to output set. Error=%s", err.Error())
+			break
+		}
+		val, err := lsInput.Read(0)
+		if err != nil {
+			t.Error(err)
+		}
+		if val != uint64(i) {
+			t.Errorf("Error on input. Expected %d, Received: %d", i, val)
+		}
+		// Now, test the value obtained by reading each pin in the set
+		// individually.
+		var sum uint64
+		for ix, line := range lsInput.Lines() {
+			if lineVal := line.Read(); lineVal {
+				sum += uint64(1 << ix)
+			}
+		}
+		if sum != uint64(i) {
+			t.Errorf("Error reading pins individually and summing them. Expected value: %d, Summed Value: %d", i, sum)
+		}
+	}
+}
+
+func clearLineSetEdges(ls *gpioioctl.LineSet) bool {
+	result := false
+	for {
+		_, _, err := ls.WaitForEdge(10 * time.Millisecond)
+		if err == nil {
+			result = true
+		} else {
+			// It timed out, so it's empty.
+			break
+		}
+	}
+	return result
+}
+
+// Test the timeout function of the LineSet WaitForEdge
+func TestLineSetWaitForEdgeTimeout(t *SmokeTestT) {
+	lsOutput, lsInput := createLineSets(t, gpioioctl.Chips[0], gpio.RisingEdge)
+	lsOutput.Close()
+	defer lsInput.Close()
+	clearLineSetEdges(lsInput)
+	tStart := time.Now().UnixMilli()
+	_, _, _ = lsInput.WaitForEdge(5 * time.Second)
+	tEnd := time.Now().UnixMilli()
+	tDiff := tEnd - tStart
+	if tDiff < 4500 || tDiff > 5500 {
+		t.Errorf("timeout duration failure. Expected duration: 5000, Actual duration: %d", tDiff)
+	}
+}
+
+// Test the halt function successfully interupts a WaitForEdge()
+func TestLineSetHalt(t *SmokeTestT) {
+	chip := gpioioctl.Chips[0]
+	lsOutput, lsInput := createLineSets(t, chip, gpio.BothEdges)
+	if lsOutput == nil || lsInput == nil {
+		return
+	}
+	lsOutput.Close() // Don't need it.
+	defer lsInput.Close()
+
+	clearLineSetEdges(lsInput)
+	// So what we'll do here is setup a goroutine to wait three seconds and then send a halt.
+	go func() {
+		time.Sleep(time.Second * 3)
+		err := lsInput.Halt()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+	tStart := time.Now().UnixMilli()
+	_, _, _ = lsInput.WaitForEdge(time.Second * 30)
+	tEnd := time.Now().UnixMilli()
+	tDiff := tEnd - tStart
+	if tDiff > 3500 {
+		t.Errorf("error calling halt to interrupt LineSet.WaitForEdge() Duration not as expected. Actual Duration: %d", tDiff)
+	}
+}
+
+// Execute WaitForEdge tests. The implementation ensures that the
+// LineSetLine.Out() and LineSetLine.Read() functions work as
+// expected too.
+func TestLineSetWaitForEdge(t *SmokeTestT) {
+	// Step 1 - Get the LineSets
+	chip := gpioioctl.Chips[0]
+	lsOutput, err := chip.LineSet(gpioioctl.LineOutput, gpio.NoEdge, gpio.PullNoChange, outputLines...)
+	if lsOutput == nil {
+		t.Errorf("Error creating output lineset. %s", err)
+	}
+	defer lsOutput.Close()
+	tests := []struct {
+		initValue    gpio.Level
+		edgeSet      gpio.Edge
+		expectedEdge gpio.Edge
+		writeValue   gpio.Level
+	}{
+		{initValue: false, edgeSet: gpio.RisingEdge, expectedEdge: gpio.RisingEdge, writeValue: true},
+		{initValue: true, edgeSet: gpio.FallingEdge, expectedEdge: gpio.FallingEdge, writeValue: false},
+		{initValue: false, edgeSet: gpio.BothEdges, expectedEdge: gpio.RisingEdge, writeValue: true},
+		{initValue: true, edgeSet: gpio.BothEdges, expectedEdge: gpio.FallingEdge, writeValue: false},
+	}
+	for _, test := range tests {
+		lsInput, err := chip.LineSet(gpioioctl.LineInput, test.edgeSet, gpio.PullUp, inputLines...)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		for ix, line := range lsOutput.Lines() {
+			inLine := lsInput.Lines()[ix]
+			// Write the initial value.
+			err = line.Out(test.initValue)
+			if err != nil {
+				t.Error(err)
+				continue
+			}
+			// Clear any queued events.
+			clearLineSetEdges(lsInput)
+			go func() {
+				// Write that line to high
+				err := line.Out(test.writeValue)
+				if err != nil {
+					t.Error(err)
+				}
+			}()
+			// lineTriggered is the line number.
+			lineTriggered, edge, err := lsInput.WaitForEdge(time.Second)
+			if err == nil {
+				if lineTriggered != uint32(inLine.Number()) {
+					t.Errorf("Test: %#v expected line: %d triggered line: %d", test, lineTriggered, line.Number())
+				}
+				if edge != test.expectedEdge {
+					t.Errorf("Test: %#v expected edge: %s received edge: %s", test, gpioioctl.EdgeLabels[test.expectedEdge], gpioioctl.EdgeLabels[edge])
+				}
+
+				if inLine.Read() != test.writeValue {
+					t.Errorf("Test: %#v received %t expected %t", test, inLine.Read(), test.writeValue)
+				}
+			} else {
+				t.Errorf("Test: %#v Line Offset: %d Error: %s", test, ix, err)
+			}
+
+		}
+		lsInput.Close()
+	}
+}
+
+// Test LineSetFromConfig with an Override on one line.
+func TestLineSetConfigWithOverride(t *SmokeTestT) {
+	chip := gpioioctl.Chips[0]
+	line0 := chip.ByName(outputLines[0])
+	line1 := chip.ByName(outputLines[1])
+	cfg := gpioioctl.LineSetConfig{
+		Lines:            []string{line0.Name(), line1.Name()},
+		DefaultDirection: gpioioctl.LineOutput,
+		DefaultEdge:      gpio.NoEdge,
+		DefaultPull:      gpio.PullNoChange,
+	}
+	err := cfg.AddOverrides(gpioioctl.LineInput, gpio.RisingEdge, gpio.PullUp, []string{line1.Name()}...)
+	if err != nil {
+		t.Errorf("AddOverrides() %s", err)
+	}
+	ls, err := chip.LineSetFromConfig(&cfg)
+	if err != nil {
+		t.Errorf("Error creating lineset with override. %s", err)
+		return
+	}
+	if ls == nil {
+		t.Error("Error creating lineset. Returned value=nil")
+		return
+	}
+	defer ls.Close()
+	lsl := ls.ByNumber(line0.Number())
+	if lsl.Number() != line0.Number() {
+		t.Errorf("LineSetLine pin 0 not as expected. Number=%d Expected: %d", lsl.Number(), line0.Number())
+	}
+	if lsl.Direction() != gpioioctl.LineOutput {
+		t.Error("LineSetLine override direction!=LineOutput")
+	}
+	if lsl.Edge() != gpio.NoEdge {
+		t.Error("LineSetLine override, edge!=gpio.NoEdge")
+	}
+	if lsl.Pull() != gpio.PullNoChange {
+		t.Error("LineSetLine override pull!=gpio.PullUp")
+	}
+
+	lsl = ls.ByNumber(line1.Number())
+	if lsl.Direction() != gpioioctl.LineInput {
+		t.Errorf("LineSetLine override direction!=LineInput ls=%s", lsl)
+	}
+	if lsl.Edge() != gpio.RisingEdge {
+		t.Error("LineSetLine override, edge!=gpio.RisingEdge")
+	}
+	if lsl.Pull() != gpio.PullUp {
+		t.Error("LineSetLine override pull!=gpio.PullUp")
+	}
+}

--- a/periph-smoketest/main.go
+++ b/periph-smoketest/main.go
@@ -27,7 +27,6 @@ import (
 	"periph.io/x/host/v3/chip/chipsmoketest"
 	"periph.io/x/host/v3/ftdi/ftdismoketest"
 	"periph.io/x/host/v3/odroidc1/odroidc1smoketest"
-	"periph.io/x/host/v3/sysfs/sysfssmoketest"
 )
 
 // SmokeTest must be implemented by a smoke test. It will be run by this
@@ -59,7 +58,6 @@ var tests = []SmokeTest{
 	&onewiresmoketest.SmokeTest{},
 	&spismoketest.SmokeTest{},
 	&ssd1306smoketest.SmokeTest{},
-	&sysfssmoketest.Benchmark{},
 }
 
 func usage(fs *flag.FlagSet) {


### PR DESCRIPTION
This is part of the GPIO IOCtl() submission.

I think there's a conflict with the sysfs still, but I'm not sure how to resolve it. Can you help?