### PR TITLE
Update installation instructions for Go 1.17 onwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ get an [invite here](https://invite.slack.golangbridge.org/).
 This directory contains directly usable tools installable via:
 
 ```
-go get periph.io/x/cmd/...
+go install periph.io/x/cmd/...@latest
 ```
 
 
@@ -28,7 +28,7 @@ https://github.com/periph/bootstrap) to cross compile and efficiently push via
 rsync:
 
 ```
-go get -u periph.io/x/bootstrap/cmd/push
+go install periph.io/x/bootstrap/cmd/push@latest
 push -host pi@raspberrypi periph.io/x/cmd/...
 ```
 


### PR DESCRIPTION
I'm new to Go and this had me confused for a spell.  Hopefully this comment makes the situation clear for others that the default behavior of `go get` has change and no longer installs executables in the `GOBIN` directory.